### PR TITLE
Fixes bug 3095

### DIFF
--- a/plugins/net.bioclipse.cdk.business/META-INF/MANIFEST.MF
+++ b/plugins/net.bioclipse.cdk.business/META-INF/MANIFEST.MF
@@ -41,8 +41,10 @@ Require-Bundle: org.openscience.cdk.io,
  net.bioclipse.inchi,
  net.bioclipse.ui.business,
  net.sf.cglib,
- org.openscience.cdk.silent;bundle-version="1.4.10",
- org.openscience.cdk.tautomer
+ org.openscience.cdk.silent,
+ org.openscience.cdk.tautomer,
+ org.openscience.cdk.renderbasic,
+ org.openscience.cdk.renderawt
 Bundle-ActivationPolicy: lazy
 Export-Package: net.bioclipse.cdk.business,
  net.bioclipse.cdk.domain,

--- a/plugins/net.bioclipse.cdk.business/src/net/bioclipse/cdk/business/ICDKManager.java
+++ b/plugins/net.bioclipse.cdk.business/src/net/bioclipse/cdk/business/ICDKManager.java
@@ -449,6 +449,33 @@ public interface ICDKManager extends IBioclipseManager {
     	          throws BioclipseException, CoreException;
 
     /**
+     * Generate and saves an image of a molecule in a file specified by path.
+     * If the file exists it gets overwritten.
+     *  
+     * @param mol The molecule that should be on the image
+     * @param path The path to the image including the image-name
+     */
+    @PublishedMethod (params = "IMolecule molecule, String filename",
+                      methodSummary = "Saves an image of a molecule in a file" )
+    public void generateImage(IMolecule mol, String path);
+    
+    /**
+     * Generate and saves an image with a specified width and height of a 
+     * molecule in a file specified by path.
+     * If the file exists it gets overwritten.
+     *  
+     * @param mol The molecule that should be on the image
+     * @param path The path to the image including the image-name
+     * @param width The width of the image
+     * @param height The height of the image
+     */
+    @PublishedMethod (params = "IMolecule molecule, String filename, int " +
+    		                "with, int height",
+                      methodSummary = "Saves an image with a specified width " +
+                      		"and height of a molecule in a file" )
+    public void generateImage(IMolecule mol, String path, int width, int height);
+    
+    /**
      * Calculate SMILES string for an IMolecule
      * @param molecule
      * @return


### PR DESCRIPTION
Adds two methods for making a 2D snapshot of a molecule to the CDK-manager. One of the methods creates a image with 600x600 pixels and the other let the user decide the image size.
