### PR TITLE
Some fixes in the add prop. to sdf wizard

### DIFF
--- a/plugins/net.bioclipse.cdk.ui.sdfeditor/src/net/bioclipse/cdk/ui/wizards/SDFPropertiesImportWizardPage.java
+++ b/plugins/net.bioclipse.cdk.ui.sdfeditor/src/net/bioclipse/cdk/ui/wizards/SDFPropertiesImportWizardPage.java
@@ -345,6 +345,9 @@ public class SDFPropertiesImportWizardPage extends WizardPage {
      * @param pathStr The path to the txt-file
      */
     private void updatePropertiesData(String pathStr) {
+        if (pathStr == null)
+            return;
+        
         try {
             Path path = new Path(pathStr);
             IFile file = ResourcesPlugin.getWorkspace().getRoot().getFile(path);


### PR DESCRIPTION
This pull request fixers the following things:
- Make the listeners for the comboboxes to check if they are the source (i.e. fixes bug 3504)
- Make the SDFPropertiesImportWizard import properties when adding a own name as well  (i.e. fixes bug 3505)
- Updates the navigator, when the new sdf-file has been created by the SDFPropertiesImportWizard. So the new file becomes visibly in the navigator without the user have to make a refresh
- Makes the open-file-dialog to start in the selected workspace root. So now it will be easier to find the wanted file.
- Removes a NPE that came if pressing cancel in the open-file-dialog when
  adding a properties file. I notised this when fixing the path thing in the point above.
