### PR TITLE
Remove the usage of some deprecated classes.

### DIFF
--- a/plugins/net.bioclipse.cdk.business/src/net/bioclipse/cdk/business/CDKManager.java
+++ b/plugins/net.bioclipse.cdk.business/src/net/bioclipse/cdk/business/CDKManager.java
@@ -1582,7 +1582,7 @@ public class CDKManager implements IBioclipseManager {
               List<List<RMap>> substructures = UniversalIsomorphismTester
               .getSubgraphMaps(molecule.getAtomContainer(),
                                substructure.getAtomContainer());
-              int i = 1;
+ 
               for (List<RMap> substruct : substructures) {
                   // convert the RMap into an IAtomContainer
                   IChemObjectBuilder scob = 


### PR DESCRIPTION
This pull request replaces the following deprecated classes:
org.openscience.cdk.nonotify.NNAtomContainer
org.openscience.cdk.nonotify.NNChemFile
org.openscience.cdk.nonotify.NNMolecule
org.openscience.cdk.nonotify.NNMoleculeSet

It also replaces, where possibly, org.openscience.cdk.interfaces.IMolecule with org.openscience.cdk.interfaces.IAtomContainer
