### PR TITLE
Added script codes to highlight part of the structure in the active editor.

### DIFF
--- a/plugins/net.bioclipse.cdk.jchempaint/src/net/bioclipse/cdk/jchempaint/business/IJChemPaintManager.java
+++ b/plugins/net.bioclipse.cdk.jchempaint/src/net/bioclipse/cdk/jchempaint/business/IJChemPaintManager.java
@@ -22,10 +22,8 @@ import net.bioclipse.core.business.BioclipseException;
 import net.bioclipse.managers.business.IBioclipseManager;
 
 import org.openscience.cdk.interfaces.IAtom;
-import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.interfaces.IChemObject;
-import org.openscience.cdk.renderer.generators.IGeneratorParameter;
 
 /**
  * Manager for the JChemPaintEditor scripting language.
@@ -421,5 +419,21 @@ public interface IJChemPaintManager extends IBioclipseManager {
     		                           "connected to the selected element",
                        params = "IChemObject element")
     public void selectPart(IChemObject element);
+    
+    @Recorded
+    @PublishedMethod(
+    	methodSummary="Selects the atoms identified by the numbers. The first atom has index 1." +
+    		"The atomIndices String is a comma separated list of atom indices.",
+    	params="String atomIndices"
+    )
+    public void selectAtoms(String atomIndices);
+
+    @Recorded
+    @PublishedMethod(
+    	methodSummary="Selects the bonds identified by the numbers. The first bond has index 1." +
+    		"The bondIndices String is a comma separated list of bond indices.",
+    	params="String atomIndices"
+    )
+    public void selectBonds(String bondIndices);
 
 }

--- a/plugins/net.bioclipse.cdk.jchempaint/src/net/bioclipse/cdk/jchempaint/business/JChemPaintManager.java
+++ b/plugins/net.bioclipse.cdk.jchempaint/src/net/bioclipse/cdk/jchempaint/business/JChemPaintManager.java
@@ -13,8 +13,10 @@
 package net.bioclipse.cdk.jchempaint.business;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 import javax.vecmath.Point2d;
 
@@ -70,6 +72,7 @@ import org.openscience.cdk.renderer.selection.IChemObjectSelection;
 import org.openscience.cdk.renderer.selection.LinkedSelection;
 import org.openscience.cdk.renderer.selection.LogicalSelection;
 import org.openscience.cdk.renderer.selection.LogicalSelection.Type;
+import org.openscience.cdk.renderer.selection.MultiSelection;
 import org.openscience.cdk.tools.manipulator.ChemModelManipulator;
 
 /**
@@ -134,6 +137,48 @@ public class JChemPaintManager implements IBioclipseManager {
                 }
             }
         });
+    }
+
+    public void selectAtoms(String atomIndices) throws BioclipseException {
+    	String[] strIndices = atomIndices.split(",");
+    	int[] atomIntices = new int[strIndices.length];
+    	for (int i=0; i<strIndices.length; i++) {
+    		atomIntices[i] = Integer.parseInt(strIndices[i].trim());
+    	}
+        JChemPaintEditor editor = findActiveEditor();
+        if (editor != null) {
+            RendererModel model = editor.getControllerHub().getRenderModel();
+        	IAtomContainer atomContainer = getModel().getAtomContainer();
+        	Set<IAtom> newSelection = new HashSet<IAtom>();
+    	    for (int number : atomIntices) {
+    	        newSelection.add( atomContainer.getAtom(number-1));
+    	    }
+    	    model.setSelection(new MultiSelection<IAtom>(newSelection));
+        } else {
+            say("No opened JChemPaint editor");
+        }
+        updateView();
+    }
+
+    public void selectBonds(String bondIndices) throws BioclipseException {
+    	String[] strIndices = bondIndices.split(",");
+    	int[] bondIntices = new int[strIndices.length];
+    	for (int i=0; i<strIndices.length; i++) {
+    		bondIntices[i] = Integer.parseInt(strIndices[i].trim());
+    	}
+        JChemPaintEditor editor = findActiveEditor();
+        if (editor != null) {
+            RendererModel model = editor.getControllerHub().getRenderModel();
+        	IAtomContainer atomContainer = getModel().getAtomContainer();
+        	Set<IBond> newSelection = new HashSet<IBond>();
+    	    for (int number : bondIntices) {
+    	        newSelection.add( atomContainer.getBond(number-1));
+    	    }
+    	    model.setSelection(new MultiSelection<IBond>(newSelection));
+        } else {
+            say("No opened JChemPaint editor");
+        }
+        updateView();
     }
 
     public ICDKMolecule getModel() throws BioclipseException {


### PR DESCRIPTION
I am using this for cheat sheets I am developing right now, with combined script to go like:

mol = cdk.fromSMILES("O=C(O)C(N)CCCCN");
jcp.setModel(mol); // reusing an existing editor here... not very robust :(
jcp.selectAtoms("1, 2, 3");

This particular example highlights the acid group of an amino acid.
