### PR TITLE
Added a IJmolEditor interface to fix the outline and scripting on active...

### DIFF
--- a/plugins/net.bioclipse.jmol/src/net/bioclipse/jmol/business/JmolManager.java
+++ b/plugins/net.bioclipse.jmol/src/net/bioclipse/jmol/business/JmolManager.java
@@ -13,12 +13,12 @@ package net.bioclipse.jmol.business;
 
 import java.util.List;
 
-import net.bioclipse.cdk.business.CDKManager;
 import net.bioclipse.cdk.business.ICDKManager;
 import net.bioclipse.core.ResourcePathTransformer;
 import net.bioclipse.core.business.BioclipseException;
 import net.bioclipse.core.domain.IMolecule;
 import net.bioclipse.jmol.Activator;
+import net.bioclipse.jmol.editors.IJmolEditor;
 import net.bioclipse.jmol.editors.JmolEditor;
 import net.bioclipse.jmol.model.IJmolMolecule;
 import net.bioclipse.jmol.views.JmolConsoleView;
@@ -35,7 +35,7 @@ import org.eclipse.ui.PlatformUI;
 
 public class JmolManager implements IBioclipseManager {
 
-    private JmolEditor jmolEditor;
+    private IJmolEditor jmolEditor;
     private ICDKManager cdk = net.bioclipse.cdk.business.Activator
             .getDefault().getJavaCDKManager();
     
@@ -50,7 +50,7 @@ public class JmolManager implements IBioclipseManager {
                 "Script parameter cannot be empty" );
 
         //Run script in editor
-        JmolEditor editor = findActiveJmolEditor();
+        IJmolEditor editor = findActiveJmolEditor();
         if (editor == null) {
             throw new IllegalStateException(
                 "Could not find any Jmol editor to run the script in" );
@@ -82,7 +82,7 @@ public class JmolManager implements IBioclipseManager {
     /**
      * @return Active editor or null if not instance of JmolEditor
      */
-    private JmolEditor findActiveJmolEditor() {
+    private IJmolEditor findActiveJmolEditor() {
 
         final Display display = PlatformUI.getWorkbench().getDisplay();
         setActiveJmolEditor(null);
@@ -94,8 +94,10 @@ public class JmolManager implements IBioclipseManager {
                                 .getActivePage()
                                 .getActiveEditor();
                 
-                if (activeEditor instanceof JmolEditor) {
-                    setActiveJmolEditor( (JmolEditor)activeEditor );
+                if (activeEditor instanceof IJmolEditor) {
+                    setActiveJmolEditor( (IJmolEditor)activeEditor );
+                } else {
+                	System.out.println("Found a non-JmolEditor: " + activeEditor.getClass().getName());
                 }
             }
         });
@@ -116,7 +118,7 @@ public class JmolManager implements IBioclipseManager {
         }
     }
 
-    protected void setActiveJmolEditor( JmolEditor activeEditor ) {
+    protected void setActiveJmolEditor( IJmolEditor activeEditor ) {
         jmolEditor = activeEditor;
     }
 
@@ -144,13 +146,13 @@ public class JmolManager implements IBioclipseManager {
     }
     
     public boolean selectionIsEmpty() {
-        JmolEditor editor = findActiveJmolEditor();
+    	IJmolEditor editor = findActiveJmolEditor();
         return editor.getSelection() == null 
             || editor.getSelection().isEmpty();
     }
 
     public void run( String script ) {
-        run( script, false );
+        run( script, true );
     }
 
     public void append( IFile file ) {
@@ -162,7 +164,10 @@ public class JmolManager implements IBioclipseManager {
     }
 
     public void append(IMolecule molecule) {
-        findActiveJmolEditor().append(molecule);
+        IJmolEditor editor = findActiveJmolEditor();
+        if (editor != null && editor instanceof JmolEditor) {
+          ((JmolEditor)editor).append(molecule);
+        }
     }
 
 }

--- a/plugins/net.bioclipse.jmol/src/net/bioclipse/jmol/editors/IJmolEditor.java
+++ b/plugins/net.bioclipse.jmol/src/net/bioclipse/jmol/editors/IJmolEditor.java
@@ -1,0 +1,33 @@
+/* Copyright (c) 2013  Egon Willighagen <egonw@users.sf.net>
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package net.bioclipse.jmol.editors;
+
+import java.util.List;
+
+import net.bioclipse.core.domain.IMolecule;
+import net.bioclipse.jmol.model.IJmolMolecule;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jface.viewers.ISelection;
+
+public interface IJmolEditor {
+
+	void runScript(String script, boolean reportErrorToJSConsole);
+
+	void load(IFile file) throws CoreException;
+
+	void snapshot(IFile file);
+
+	ISelection getSelection();
+
+	void append(IFile file);
+
+	List<IJmolMolecule> getJmolMolecules();
+
+}

--- a/plugins/net.bioclipse.jmol/src/net/bioclipse/jmol/editors/JmolEditor.java
+++ b/plugins/net.bioclipse.jmol/src/net/bioclipse/jmol/editors/JmolEditor.java
@@ -112,7 +112,8 @@ public class JmolEditor extends EditorPart
                         implements IResourceChangeListener, 
                                    IAdaptable, 
                                    ISelectionListener, 
-                                   ISelectionProvider {
+                                   ISelectionProvider,
+                                   IJmolEditor {
 
     public static final String EDITOR_ID 
         = "net.bioclipse.jmol.editors.JmolEditor";

--- a/plugins/net.bioclipse.jmol/src/net/bioclipse/jmol/editors/JmolProteinEditor.java
+++ b/plugins/net.bioclipse.jmol/src/net/bioclipse/jmol/editors/JmolProteinEditor.java
@@ -108,7 +108,8 @@ public class JmolProteinEditor extends EditorPart
                         implements IResourceChangeListener, 
                                    IAdaptable, 
                                    ISelectionListener, 
-                                   ISelectionProvider {
+                                   ISelectionProvider,
+                                   IJmolEditor {
 
     public static final String EDITOR_ID 
         = "net.bioclipse.jmol.editors.JmolProteinEditor";


### PR DESCRIPTION
... JmolProteinEditors.

Arvid, this is an important fix. The current Bioclipse release does show the protein residues properly in the outline, but selecting one does not select anything in the editor.

The problem was a "instanceof JmolEditor" where the recent new JmolEditor was not extending this error, and thus the instanceof failing. I fixed this by introducing an interface that both Jmol editors implement.
