### PR TITLE
Adds recalculation of atom typing and aromaticy detection

### DIFF
--- a/plugins/net.bioclipse.cdk.business/src/net/bioclipse/cdk/business/CDKManager.java
+++ b/plugins/net.bioclipse.cdk.business/src/net/bioclipse/cdk/business/CDKManager.java
@@ -172,6 +172,7 @@ import org.openscience.cdk.tools.AtomTypeAwareSaturationChecker;
 import org.openscience.cdk.tools.CDKHydrogenAdder;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 import org.openscience.cdk.tools.manipulator.AtomTypeManipulator;
+import org.openscience.cdk.tools.manipulator.BondManipulator;
 import org.openscience.cdk.tools.manipulator.ChemFileManipulator;
 import org.openscience.cdk.tools.manipulator.ChemModelManipulator;
 import org.openscience.cdk.tools.manipulator.MolecularFormulaManipulator;
@@ -1114,12 +1115,16 @@ public class CDKManager implements IBioclipseManager {
           try {
               AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms( molecule );
               ataSatChecker.decideBondOrder( molecule );
-//        	  molecule = fbot.kekuliseAromaticRings(molecule);
+              AtomContainerManipulator.clearAtomConfigurations( molecule );
+              AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms( molecule );
+              CDKHueckelAromaticityDetector.detectAromaticity(molecule);
+
           } catch (CDKException exception) {
         	  logger.warn("Could not figure out the double bond positions: " + exception.getMessage());
           } catch (NullPointerException npe) {
         	  throw new IllegalStateException("Could not create molecule from: "+smilesDescription,npe);
-          }
+          } 
+          
           return new CDKMolecule(molecule);
       }
 


### PR DESCRIPTION
This is done after the orders of the bonds in the molecule have been decided. It fixes bug 3538.

My only worry is that this will result in an overlap and make the calculation of long and/or complicated SMILES to take unmotivated long time.
