### PR TITLE
updates for the new SMILES API

### DIFF
--- a/plugins/net.bioclipse.cdk.business/src/net/bioclipse/cdk/business/CDKManager.java
+++ b/plugins/net.bioclipse.cdk.business/src/net/bioclipse/cdk/business/CDKManager.java
@@ -609,11 +609,7 @@ public class CDKManager implements IBioclipseManager {
             IAtomContainer cdkMol = mol.getAtomContainer();
 
             // Create the SMILES
-            SmilesGenerator generator = new SmilesGenerator();
-
-            // Operate on a clone with removed hydrogens
-            cdkMol = AtomContainerManipulator.removeHydrogens( cdkMol );
-
+            SmilesGenerator generator = SmilesGenerator.absolute();
             result = generator.create( cdkMol );
         }catch (Exception e) {
             logger.warn( "Failed to generate SMILES",e);

--- a/plugins/net.bioclipse.cdk.business/src/net/bioclipse/cdk/business/CDKManager.java
+++ b/plugins/net.bioclipse.cdk.business/src/net/bioclipse/cdk/business/CDKManager.java
@@ -1065,40 +1065,31 @@ public class CDKManager implements IBioclipseManager {
           String fullPath = file.getLocation().toOSString();
           ImageIO.write( (RenderedImage) image, "PNG", new File(fullPath) );
       }
-      
-      private AtomTypeAwareSaturationChecker ataSatChecker = new AtomTypeAwareSaturationChecker();
-//      private FixBondOrdersTool fbot = new FixBondOrdersTool();
-      
+
       /**
        * Create molecule from SMILES.
        *
        * @throws BioclipseException
        */
       public ICDKMolecule fromSMILES(String smilesDescription)
-                          throws BioclipseException {
-
-          SmilesParser parser
-              = new SmilesParser( SilentChemObjectBuilder.getInstance() );
-		parser.setPreservingAromaticity( true );
-        IAtomContainer molecule;
+              throws BioclipseException {
+          SmilesParser parser = new SmilesParser( SilentChemObjectBuilder.getInstance() );
+          IAtomContainer molecule;
           try {
-            molecule = parser.parseSmiles( smilesDescription.trim() );
-          }
-          catch (InvalidSmilesException e) {
-            String message = "SMILES string is invalid. Error message said: ";
-            throw new BioclipseException( message + e.getMessage(), e );
+              molecule = parser.parseSmiles( smilesDescription.trim() );
+          } catch (InvalidSmilesException e) {
+              String message = "SMILES string is invalid. Error message said: ";
+              throw new BioclipseException( message + e.getMessage(), e );
           }
           try {
               Aromaticity arom = new Aromaticity(ElectronDonation.cdk(),Cycles.cdkAromaticSet());
               AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms( molecule );
               arom.apply( molecule);
-              ataSatChecker.decideBondOrder( molecule );
           } catch (CDKException exception) {
-        	  logger.warn("Could not figure out the double bond positions: " + exception.getMessage());
+              logger.warn("Could not figure out the double bond positions: " + exception.getMessage());
           } catch (NullPointerException npe) {
-        	  throw new IllegalStateException("Could not create molecule from: "+smilesDescription,npe);
+              throw new IllegalStateException("Could not create molecule from: " + smilesDescription, npe);
           } 
-          
           return new CDKMolecule(molecule);
       }
 

--- a/plugins/net.bioclipse.cdk.business/src/net/bioclipse/cdk/domain/CDKMolecule.java
+++ b/plugins/net.bioclipse.cdk.business/src/net/bioclipse/cdk/domain/CDKMolecule.java
@@ -288,8 +288,8 @@ public class CDKMolecule extends BioObject implements ICDKMolecule {
         if(val instanceof InChI) return ((InChI)val).getValue();
         if(urgency==Property.USE_CACHED) return "";
 
-        String result = ensureFullAtomTyping(atomContainer);
-        if (result.length() > 0) return result;
+//        String result = ensureFullAtomTyping(atomContainer);
+//        if (result.length() > 0) return result;
 
         IInChIManager inchi = net.bioclipse.inchi.business.Activator.
             getDefault().getJavaInChIManager();

--- a/plugins/net.bioclipse.cdk.business/src/net/bioclipse/cdk/domain/CDKMolecule.java
+++ b/plugins/net.bioclipse.cdk.business/src/net/bioclipse/cdk/domain/CDKMolecule.java
@@ -104,20 +104,8 @@ public class CDKMolecule extends BioObject implements ICDKMolecule {
      */
     public String toSMILES() throws BioclipseException {
         if (getAtomContainer() == null) return "";
-        IAtomContainer container = getAtomContainer();
-
-        //Operate on a clone with removed hydrogens
-        IAtomContainer hydrogenlessClone =
-            container.getBuilder().newInstance(
-            	IAtomContainer.class,
-                AtomContainerManipulator.removeHydrogens(container)
-            );
-
-        String result = ensureFullAtomTyping(hydrogenlessClone);
-        if (result.length() > 0) return result;
-
         try {
-            return new SmilesGenerator().create( hydrogenlessClone );
+            return SmilesGenerator.absolute().create( getAtomContainer() );
         } catch ( CDKException e ) {
             throw new BioclipseException( e.getMessage(), e );
         }

--- a/plugins/net.bioclipse.cdk.jchempaint/src/net/bioclipse/cdk/jchempaint/editor/MoleculePropertySection.java
+++ b/plugins/net.bioclipse.cdk.jchempaint/src/net/bioclipse/cdk/jchempaint/editor/MoleculePropertySection.java
@@ -1,11 +1,8 @@
 package net.bioclipse.cdk.jchempaint.editor;
 
-import net.bioclipse.cdk.business.ICDKManager;
-import net.bioclipse.cdk.business.IJavaCDKManager;
 import net.bioclipse.cdk.domain.CDKMolecule;
 import net.bioclipse.cdk.domain.CDKMoleculePropertySource;
 import net.bioclipse.cdk.domain.ICDKMolecule;
-import net.bioclipse.core.business.BioclipseException;
 import net.bioclipse.core.domain.IMolecule.Property;
 import net.bioclipse.inchi.InChI;
 import net.bioclipse.inchi.business.Activator;
@@ -35,7 +32,6 @@ import org.eclipse.ui.views.properties.IPropertySource;
 import org.eclipse.ui.views.properties.tabbed.AbstractPropertySection;
 import org.eclipse.ui.views.properties.tabbed.ITabbedPropertyConstants;
 import org.eclipse.ui.views.properties.tabbed.TabbedPropertySheetPage;
-import org.openscience.cdk.interfaces.IAtomContainer;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
@@ -111,30 +107,6 @@ public class MoleculePropertySection extends AbstractPropertySection {
 
                 final ICDKMolecule item = molecule;
 
-                boolean allOK = true;
-                try {
-                    IAtomContainer container = item.getAtomContainer().clone();
-                    String result = CDKMoleculePropertySource.ensureFullAtomTyping( container );
-                    if ( result == null || result.length() > 0 )
-                        allOK = false;
-                } catch ( CloneNotSupportedException e1 ) {
-                    allOK = false;
-                }
-                if ( !allOK ) {
-                    String msg = "Incorrect Structure.";
-                    item.setProperty( CDKMolecule.INCHI_OBJECT, msg );
-                    refresh();
-                }
-
-                ICDKManager cdk = getService( IJavaCDKManager.class );
-                final ICDKMolecule inchiClone;
-                try {
-                    inchiClone  = cdk.clone( item );
-                }
-                catch ( BioclipseException ex ) {
-                    throw new RuntimeException( ex );
-                }
-
                 if ( item.getProperty( CDKMolecule.INCHI_OBJECT,
                                        Property.USE_CACHED ) == null ) {
                     Job j = new Job( "Calculating inchi for properties view" ) {
@@ -145,7 +117,7 @@ public class MoleculePropertySection extends AbstractPropertySection {
                             IInChIManager inchi = Activator.getDefault()
                                             .getJavaInChIManager();
                             try {
-                            	InChI inc = inchi.generate( inchiClone ) ;
+                            	InChI inc = inchi.generate( item ) ;
                                 item.setProperty( CDKMolecule.INCHI_OBJECT,
                                                   inc);
                             } catch ( Exception e ) {


### PR DESCRIPTION
Hi @olas @goglepox,

thanks for pushing the patches to use CDK 1.5.13! I have pulled them in locally and with my new expectations around SMILES, I wrote a few patches. For example, chirality in SMILES is fully supported now, both when parsing as when generation SMILES. But this was not reflected in Bioclipse yet, because past workaround code undid what the new CDK actually does correctly now. So, chirality was lost in Bioclipse. These patches fix that. I had to fix code in the CDKManager, CDKMolecule, and Property View stack.

That said, when reading a SMILES, it does not assign wedge bonds yet; I need to figure out how to do that, as I know that that is possible too.

This test code (Groovy) shows that chirality is preserved with these patches (but not without them):

    smiles = "O=C(NC[C@@H](N(C)C)Cc1ccc(O)cc1)N[C@@H](C)Cc2ccsc2"
    mol = cdk.fromSMILES(smiles)
    
    println mol.toSMILES()
    println mol.getInChI()
    println mol.getInChIKey()
    println mol.toSMILES()
    
    ui.open(mol)

WARNING: however, while this solves things are a scripting level, and with the properties view linked to the JChemPaint editor pane, there is bound to be other affected stuff, with workarounds build on workarounds.

Things that may need checking:

- the QSAR stack
- R,S calculation and use
